### PR TITLE
wombag-search: Add w-search-open-in-wallabag

### DIFF
--- a/wombag-search.el
+++ b/wombag-search.el
@@ -509,6 +509,13 @@ With prefix ARG only quit Wombag."
    (when-let ((url (map-elt entry 'url)))
      (eww url))))
 
+(defun w-search-open-in-wallabag ()
+  "Open Wombag entry at point in Wallabag web interface."
+  (interactive)
+  (let ((id (get-text-property (point) 'wombag-id)))
+    (funcall wombag-browse-url-function
+             (format "%s/view/%s" wombag-host id))))
+
 (defun w-search-copy ()
   "Copy URL of Wombag entry at point."
   (interactive)
@@ -707,6 +714,7 @@ When NO-CONFIRM is non-nil, do not ask for confirmation."
   "B" #'w-search-eww-open
   "&" #'w-search-browse-url
   "x" #'w-search-browse-url
+  "W" #'w-search-open-in-wallabag
   "s" #'w-search-live-filter
   "q" #'w-search-quit-window
   "g" #'w-search-update--force

--- a/wombag-show.el
+++ b/wombag-show.el
@@ -173,6 +173,13 @@ Render from positions BEGIN to END."
              (shr-inhibit-images t))
     (w-show-entry entry)))
 
+(defun w-show-open-in-wallabag ()
+  "Open this Wombag article in Wallabag web interface."
+  (interactive)
+  (when-let ((id (alist-get 'id w-show-entry)))
+    (funcall wombag-browse-url-function
+             (format "%s/view/%s" wombag-host id))))
+
 
 ;;; Major mode
 (defvar-keymap w-show-mode-map
@@ -184,6 +191,7 @@ Render from positions BEGIN to END."
   "DEL"       #'scroll-down-command
   "<"         #'beginning-of-buffer
   ">"         #'end-of-buffer
+  "W"         #'w-show-open-in-wallabag
   "q"         #'w-show-quit-window
   "I"         #'w-show-disable-images
   "C-c C-n"   #'w-heading-next


### PR DESCRIPTION
I'm really liking Wombag as a Wallabag interface, especially because it feels so much like elfeed. I really love how you've made the live search so easy to use because of the help buffer.

While playing around with Wombag, I came up with the following function that might be useful to other users as well. I like to highlight passages as I read them, so I often visit articles in the web-interface. This pull request provides a function and a key for that.

Original commit comment: New function in wombag-search to open entry at point in the Wallabag web interface, using wombag-browse-url-function.